### PR TITLE
made virtualenv compatible; prettified state report json and set the correct content type

### DIFF
--- a/README
+++ b/README
@@ -177,6 +177,10 @@ state reporting, write something like this into your config file ::
   bucket_name = statusreport-bucket
   # The "filename" in the bucket that you want to report to
   key = file/in/bucket
+  # The ACL for the report (defaults to private)
+  acl = public-read
+  # The content type for the report (guesses from key by default)
+  content_type = application/json
 
 The output format of the file is json.
 

--- a/run-tests
+++ b/run-tests
@@ -2,8 +2,26 @@
 
 import os
 import subprocess
+import sys
 
-pythonpath = os.environ['PYTHONPATH']
+
+def virtualenv_pypath():
+    """
+    Returns the python path if running in an activated virtual env.
+    """
+    virtual_env = os.environ.get('VIRTUAL_ENV')
+    if not virtual_env:
+        return
+
+    interpreter = "python%s" % sys.version[:3]
+
+    site_packages = os.path.join(virtual_env, "lib", interpreter,
+                                 "site-packages")
+
+    return site_packages
+
+
+pythonpath = os.environ.get('PYTHONPATH') or virtualenv_pypath()
 cwd = os.getcwd()
 
 

--- a/scripts/kuberoute
+++ b/scripts/kuberoute
@@ -233,7 +233,13 @@ def report_state_to_s3(records, nodes, cluster_available, s3_report):
         'available': cluster_available,
         'services': record_info,
     }
-    yield s3_report.write(json.dumps(cluster_info))
+    cluster_info_json = json.dumps(
+        cluster_info,
+        sort_keys=True,
+        indent=4,
+        separators=(',', ': ')
+    )
+    yield s3_report.write(cluster_info_json)
 
 
 @do
@@ -308,6 +314,8 @@ def main():
             bucket_name=s3_report_config['bucket_name'],
             aws_access_key_id=s3_report_config['aws_access_key_id'],
             aws_secret_access_key=s3_report_config['aws_secret_access_key'],
+            acl=s3_report_config.get('acl', 'private'),
+            content_type=s3_report_config.get('content_type', 'application/json'),
         )
     except (configparser.NoSectionError, KeyError):
         s3_report = None


### PR DESCRIPTION
There is no PYTHONPATH environment variable set in an activated virtualenv. I made the script use the virtualenv's site-packages directory if there is no PYTHONPATH environment variable set.